### PR TITLE
Allow for Oh My Zsh integration.

### DIFF
--- a/git/gitconfig.symlink
+++ b/git/gitconfig.symlink
@@ -5,9 +5,9 @@
         protocol = https
 [alias]
         co = checkout
-        promote = !$ZSH/bin/git-promote
-        wtf     = !$ZSH/bin/git-wtf
-        rank-contributors = !$ZSH/bin/git-rank-contributors
+        promote = !$DOTFILES/bin/git-promote
+        wtf     = !$DOTFILES/bin/git-wtf
+        rank-contributors = !$DOTFILES/bin/git-rank-contributors
         count   = !git shortlog -sn
 [color]
         diff = auto

--- a/zsh/prompt.zsh
+++ b/zsh/prompt.zsh
@@ -55,7 +55,7 @@ directory_name() {
 }
 
 battery_status() {
-  $ZSH/bin/battery-status
+  $DOTFILES/bin/battery-status
 }
 
 export PROMPT=$'\n$(battery_status)in $(directory_name) $(git_dirty)$(need_push)\n› '

--- a/zsh/zshrc.symlink
+++ b/zsh/zshrc.symlink
@@ -1,5 +1,8 @@
-# shortcut to this dotfiles path is $ZSH
-export ZSH=$HOME/.dotfiles
+# shortcut to this dotfiles path is $DOTFILES
+export DOTFILES=$HOME/.dotfiles
+
+# $ZSH variable is deprecated, use $DOTFILES instead
+export ZSH="$DOTFILES"
 
 # your project folder that we can `c [tab]` to
 export PROJECTS=~/Code
@@ -14,7 +17,7 @@ fi
 
 # all of our zsh files
 typeset -U config_files
-config_files=($ZSH/**/*.zsh)
+config_files=($DOTFILES/**/*.zsh)
 
 # load the path files
 for file in ${(M)config_files:#*/path.zsh}
@@ -28,9 +31,20 @@ do
   source $file
 done
 
-# initialize autocomplete here, otherwise functions won't be loaded
-autoload -U compinit
-compinit
+# Oh My Zsh could be installed somewhere out of dotfiles directory tree, e.g.
+# into  ~/.oh-my-zsh; the configuration file created by Oh My Zsh installer
+# should be moved as follows: {.zshrc => $DOTFILES/zsh/oh-my-zshrc}.
+if [[ -f $DOTFILES/zsh/oh-my-zshrc ]]; then
+  () {
+    local ZSH="$HOME/.oh-my-zsh"
+    source $DOTFILES/zsh/oh-my-zshrc
+    export OHMYZSH="$ZSH"
+  }
+else
+  # initialize autocomplete here, otherwise functions won't be loaded
+  autoload -U compinit
+  compinit
+fi
 
 # load every completion after autocomplete loads
 for file in ${(M)config_files:#*/completion.zsh}
@@ -39,3 +53,6 @@ do
 done
 
 unset config_files
+
+# Notify existing users that they should migrate to another variable.
+export ZSH='$ZSH is deprecated, use either $DOTFILES or $OHMYZSH instead.'


### PR DESCRIPTION
Start replacing $ZSH variable with $DOTFILES in a backward-compatible
way, so that existing users have a chance to migrate.